### PR TITLE
introduced Specs to check gateway errors with incompatible shipping addrss

### DIFF
--- a/spec/features/orders/placing_a_klarna_order_with_non_supported_address_spec.rb
+++ b/spec/features/orders/placing_a_klarna_order_with_non_supported_address_spec.rb
@@ -1,57 +1,14 @@
 require 'features_helper'
 
-describe 'Orders to non-supported countries', type: 'feature', bdd: true, no_klarna: true do
+describe 'Orders to non-supported countries', type: 'feature', bdd: true, no_klarna: true, only: :us do
   include_context "ordering with klarna"
   include WorkflowDriver::Process
 
-  xit 'gateway should be unavailable when shipping to a non-supported country' do
+  it 'Gateway should be unavailable when shipping to a non-supported country (Canada)' do
     product_name = 'Ruby on Rails Mug'
     product_quantity = 2
 
-    on_the_home_page do |page|
-      page.load
-      expect(page.displayed?).to be(true)
-
-      page.choose(product_name)
-    end
-
-    on_the_product_page do |page|
-      page.wait_for_title
-      expect(page.displayed?).to be(true)
-
-      expect(page.title).to have_content(product_name)
-      page.add_to_cart(product_quantity)
-    end
-
-    on_the_cart_page do |page|
-      page.line_items
-      expect(page.displayed?).to be(true)
-
-      expect(page.line_items).to have_content(product_name)
-
-      page.continue
-    end
-
-    on_the_registration_page do |page|
-      expect(page.displayed?).to be(true)
-
-      page.checkout_as_guest(@testing_data.ca_address.email)
-    end
-
-    on_the_address_page do |page|
-      expect(page.displayed?).to be(true)
-      page.set_address(@testing_data.ca_address)
-
-      page.continue
-    end
-
-    on_the_delivery_page do |page|
-      expect(page.displayed?).to be(true)
-      page.stock_contents.each do |stocks|
-        expect(stocks).to have_content(product_name)
-      end
-      page.continue
-    end
+    order_with_different_address(@testing_data.ca_address, product_name, product_quantity)
 
     on_the_payment_page do |page|
       expect(page.displayed?).to be(true)
@@ -61,15 +18,98 @@ describe 'Orders to non-supported countries', type: 'feature', bdd: true, no_kla
         expect(frame).to have_content('Not available for this country')
       end
 
-      page.select_payment_method('Check').click
-
-      page.continue
-    end
-
-    on_the_confirm_page do |page|
-      expect(page.displayed?).to be(true)
-
-      page.continue
+      Capybara.current_session.driver.quit
     end
   end
+
+  it 'Gateway should be unavailable when shipping to a non-supported country (Germany)' do
+    product_name = 'Ruby on Rails Mug'
+    product_quantity = 2
+
+    order_with_different_address(@testing_data.de_address, product_name, product_quantity)
+
+    on_the_payment_page do |page|
+      expect(page.displayed?).to be(true)
+      page.select_payment_method(@testing_data.payment_name).click
+
+      page.klarna_credit do |frame|
+        expect(frame).to have_content('Zahlungsart nicht verfügbar in diesem Land')
+      end
+
+      Capybara.current_session.driver.quit
+    end
+  end
+
+  it 'Gateway should be unavailable when shipping to a non-supported country (UK)' do
+    product_name = 'Ruby on Rails Mug'
+    product_quantity = 2
+
+    order_with_different_address(@testing_data.uk_address, product_name, product_quantity)
+
+    on_the_payment_page do |page|
+      expect(page.displayed?).to be(true)
+      page.select_payment_method(@testing_data.payment_name).click
+
+      page.klarna_credit do |frame|
+        expect(frame).to have_content('Not available for this country')      
+      end
+
+      Capybara.current_session.driver.quit
+    end
+  end
+
+  it 'Gateway should be unavailable when shipping to a non-supported country (Norway)' do
+    product_name = 'Ruby on Rails Mug'
+    product_quantity = 2
+
+    order_with_different_address(@testing_data.no_address, product_name, product_quantity)
+
+    on_the_payment_page do |page|
+      expect(page.displayed?).to be(true)
+      page.select_payment_method(@testing_data.payment_name).click
+
+      page.klarna_credit do |frame|
+        expect(frame).to have_content('Ikke tilgjengelig i dette landet')      
+      end
+
+      Capybara.current_session.driver.quit
+    end
+  end
+
+  it 'Gateway should be unavailable when shipping to a non-supported country (Sweden)' do
+    product_name = 'Ruby on Rails Mug'
+    product_quantity = 2
+
+    order_with_different_address(@testing_data.se_address, product_name, product_quantity)
+
+    on_the_payment_page do |page|
+      expect(page.displayed?).to be(true)
+      page.select_payment_method(@testing_data.payment_name).click
+
+      page.klarna_credit do |frame|
+        expect(frame).to have_content('Betalsätt ej tillgängligt för det här landet')    
+      end
+
+      Capybara.current_session.driver.quit
+    end
+  end
+
+  it 'gateway should be unavailable when shipping to a non-supported country (Finland)' do
+    product_name = 'Ruby on Rails Mug'
+    product_quantity = 2
+
+    order_with_different_address(@testing_data.fi_address, product_name, product_quantity)
+
+    on_the_payment_page do |page|
+      expect(page.displayed?).to be(true)
+      page.select_payment_method(@testing_data.payment_name).click
+
+      page.klarna_credit do |frame|
+        expect(frame).to have_content('Maksutapa ei ole saatavilla tässä maassa')      
+      end
+
+      Capybara.current_session.driver.quit
+    end
+  end
+
 end

--- a/spec/support/fixtures/data.rb
+++ b/spec/support/fixtures/data.rb
@@ -115,7 +115,7 @@ class TestData
 
   def ca_address
     Address.new(
-      'Testperson-fi',        # Name
+      'Testperson-ca',        # Name
       'Approved',             # Last Name
       '17007 107 Ave',        # Stree
       'Edmonton',             # City

--- a/spec/support/shared_contexts/ordering_with_klarna.rb
+++ b/spec/support/shared_contexts/ordering_with_klarna.rb
@@ -120,4 +120,52 @@ shared_context "ordering with klarna" do
       page.get_order_number
     end
   end
+
+  def order_with_different_address(address, product_name, product_quantity)
+    on_the_home_page do |page|
+      page.load
+      expect(page.displayed?).to be(true)
+
+      page.choose(product_name)
+    end
+
+    on_the_product_page do |page|
+      page.wait_for_title
+      expect(page.displayed?).to be(true)
+
+      expect(page.title).to have_content(product_name)
+      page.add_to_cart(product_quantity)
+    end
+
+    on_the_cart_page do |page|
+      page.line_items
+      expect(page.displayed?).to be(true)
+
+      expect(page.line_items).to have_content(product_name)
+
+      page.continue
+    end
+
+    on_the_registration_page do |page|
+      expect(page.displayed?).to be(true)
+
+      page.checkout_as_guest(address.email)
+    end
+
+    on_the_address_page do |page|
+      expect(page.displayed?).to be(true)
+      page.set_address(address)
+
+      page.continue
+    end
+
+    on_the_delivery_page do |page|
+      expect(page.displayed?).to be(true)
+      page.stock_contents.each do |stocks|
+        expect(stocks).to have_content(product_name)
+      end
+      page.continue
+    end
+  end
+
 end


### PR DESCRIPTION
# What does this PR do?

This PR checks that when a user specifies a shipping address that is incompatible with the store (e.g. Canadian shipping address with a Store configured to US), the correct error message is rendered in the payment gateway.

**These error messages are localised**

DE address = error message in German
NO address = error message in Norwegian

## Notes
- `Capybara.current_session.driver.quit` are essential for incompleted Spree Orders, if not added the store will cache previous order details and create a significant amount of issues for any test that follows.
- Only testing on `US store`