### PR TITLE
Add dependency Deface, needed for Solidus versions below 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 solidus_version = ENV["SOLIDUS_VERSION"] || "~> 1.3.0"
 rails_version = ENV["RAILS_VERSION"] || "~> 4.2.0"
 
+gem "deface"
 gem "solidus", solidus_version
 gem "rails", rails_version
 


### PR DESCRIPTION
Deface is a dependency needed for certain versions of Solidus, tests will not pass without it.